### PR TITLE
Not happi

### DIFF
--- a/config/macros/tmo.macros.json
+++ b/config/macros/tmo.macros.json
@@ -1,7 +1,7 @@
 {
-   "location" : "SLAC:LCLS:tmo",
-   "hutch" : "tmo",
+   "location" : "SLAC:LCLS:TMO",
+   "hutch" : "TMO",
    "iocname" : "ioc-tmo-pcdsdevices",
-   "engineer_name" : "engineer",
-   "engineer_username" : "engineer"
+   "engineer_name" : "Tyler Pennebaker",
+   "engineer_username" : "pennebak"
 }

--- a/config/notepad/ioc-tmo-pcdsdevices.cfg
+++ b/config/notepad/ioc-tmo-pcdsdevices.cfg
@@ -1,8 +1,8 @@
-RELEASE=/reg/g/pcds/epics/ioc/common/pvNotepad/R2.1.0
+RELEASE=/reg/g/pcds/epics/ioc/common/pvNotepad/R2.0.3
 
-ARCH=linux-x86_64
-ENGINEER=engineer (engineer)
-LOCATION=SLAC:LCLS:tmo
+ARCH=rhel7-x86_64
+ENGINEER=Tyler Pennebaker (pennebak)
+LOCATION=SLAC:LCLS:TMO
 
 IOCNAME=ioc-tmo-pcdsdevices
 HUTCH=TMO
@@ -15,4 +15,11 @@ LONGOUT_1 =
 LONGOUT_10 =
 LONGOUT_20 =
 
-
+SPECIAL(PV=:sync:OphydReadback,RECTYPE=ao,DTYP="Soft Channel",DESC="lxt_ttc.notepad_readback",VAL=0.0)
+SPECIAL(PV=:sync:OphydSetpoint,RECTYPE=ao,DTYP="Soft Channel",DESC="lxt_ttc.notepad_setpoint",VAL=0.0)
+SPECIAL(PV=LAS:FS14:lxt:OphydOffset,RECTYPE=ao,DTYP="Soft Channel",DESC="lxt.user_offset",VAL=0.0)
+SPECIAL(PV=LAS:FS14:lxt:OphydReadback,RECTYPE=ao,DTYP="Soft Channel",DESC="lxt.notepad_readback",VAL=0.0)
+SPECIAL(PV=LAS:FS14:lxt:OphydSetpoint,RECTYPE=ao,DTYP="Soft Channel",DESC="lxt.notepad_setpoint",VAL=0.0)
+SPECIAL(PV=LM1K4:COM_MP2_DLY1:OphydOffset,RECTYPE=ao,DTYP="Soft Channel",DESC="txt.user_offset",VAL=0.0)
+SPECIAL(PV=LM1K4:COM_MP2_DLY1:delay:OphydReadback,RECTYPE=ao,DTYP="Soft Channel",DESC="txt.notepad_readback",VAL=0.0)
+SPECIAL(PV=LM1K4:COM_MP2_DLY1:delay:OphydSetpoint,RECTYPE=ao,DTYP="Soft Channel",DESC="txt.notepad_setpoint",VAL=0.0)

--- a/config/notepad_finder.py
+++ b/config/notepad_finder.py
@@ -7,7 +7,7 @@ import fnmatch
 import json
 import logging
 import typing
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 import happi
 import ophyd
@@ -245,26 +245,52 @@ def _get_argparser(parser: typing.Optional[argparse.ArgumentParser] = None):
     return parser
 
 
-def find_notepad_signals(*devices, output=None):
-    patch_and_use_dummy_shim()
+def find_signals_from_devices(
+    *devices: ophyd.Device, output: Optional[str] = None
+) -> List[Dict]:
+    """
+    From the provided devices, find any NotepadLinkedSignal instances.
+
+    May be used in a shared hutch-python environment as it does not change the
+    underlying ophyd control layer.
+
+    Parameters
+    ----------
+    *devices : ophyd.Device
+        Devices to check.
+
+    output : str, optional
+        Filename to write results to.  Defaults to standard output if not
+        provided.
+
+    Returns
+    -------
+    results : list of dict
+        List of metadata dictionaries.
+    """
 
     def is_notepad_signal(obj):
-        return isinstance(obj, pcdsdevices.signal.NotepadLinkedSignal) 
+        return isinstance(obj, pcdsdevices.signal.NotepadLinkedSignal)
 
     found = {}
     for dev in devices:
+        if not isinstance(dev, ophyd.Device):
+            continue
+
         for sig in get_components_matching(dev, predicate=is_notepad_signal):
             metadata = sig.notepad_metadata
             found[metadata['read_pv']] = metadata
 
-    results = list(metadata for key, metadata in
-                sorted(found.items(), key=lambda keyval: keyval[0]))
+    results = list(
+        metadata
+        for _, metadata in sorted(found.items(), key=lambda keyval: keyval[0])
+    )
 
-    if output is None:
-        return results
-    else:
+    if output is not None:
         with open(output, 'wt') as f:
             json.dump(results, f, sort_keys=True, indent=4)
+
+    return results
 
 
 if __name__ == '__main__':

--- a/config/notepad_finder.py
+++ b/config/notepad_finder.py
@@ -245,6 +245,28 @@ def _get_argparser(parser: typing.Optional[argparse.ArgumentParser] = None):
     return parser
 
 
+def find_notepad_signals(*devices, output=None):
+    patch_and_use_dummy_shim()
+
+    def is_notepad_signal(obj):
+        return isinstance(obj, pcdsdevices.signal.NotepadLinkedSignal) 
+
+    found = {}
+    for dev in devices:
+        for sig in get_components_matching(dev, predicate=is_notepad_signal):
+            metadata = sig.notepad_metadata
+            found[metadata['read_pv']] = metadata
+
+    results = list(metadata for key, metadata in
+                sorted(found.items(), key=lambda keyval: keyval[0]))
+
+    if output is None:
+        return results
+    else:
+        with open(output, 'wt') as f:
+            json.dump(results, f, sort_keys=True, indent=4)
+
+
 if __name__ == '__main__':
     parser = _get_argparser()
     args = parser.parse_args()

--- a/config/pvnotepad_template.cfg
+++ b/config/pvnotepad_template.cfg
@@ -1,6 +1,5 @@
 RELEASE=/reg/g/pcds/epics/ioc/common/pvNotepad/R2.1.0
-
-ARCH=linux-x86_64
+ARCH=rhel7-x86_64
 ENGINEER={{ engineer_name }} ({{ engineer_username }})
 LOCATION={{ location }}
 


### PR DESCRIPTION
Hey, I wrote this little function to make it easier for me to set up notepad PVs for devices that aren't in happi. I just import it in a hutch-python python instance, and feed it some of the devices that are set up in beamline.py or elsewhere.

It's just built from other chunks in your `find_signals` function. Not sure if you want something like this in here but thought I'd just share it here. You can also feel free to mess with this branch if you want to edit it at all.